### PR TITLE
#233 project colors to tailwind

### DIFF
--- a/frontend/src/components/units/Button/Button.styles.js
+++ b/frontend/src/components/units/Button/Button.styles.js
@@ -7,22 +7,22 @@ const StyledButton = styled.button.attrs({
 	box-shadow: ${theme`boxShadow.button-shadow`};
 
 	&.blueGradient {
-		${tw`text-white bg-gradient-to-r from-sky-400 to-sky-600 hover:from-sky-500 hover:to-sky-700 p-1`}
+		${tw`text-white opacity-100 bg-gradient-to-r from-lightBlue to-darkBlue hover:opacity-90  p-1`}
 	}
 	&.orangeGradient {
-		${tw`text-white bg-gradient-to-r from-orange-400 to-orange-500 hover:from-orange-500 hover:to-orange-600 p-1`}
+		${tw`text-white opacity-100 bg-gradient-to-r from-lightOrange to-darkOrange hover:opacity-90  p-1`}
 	}
 	&.blueGradientProfile {
-		${tw`w-28 text-white bg-gradient-to-r from-sky-400 to-sky-600 hover:from-sky-500 hover:to-sky-700 p-1`}
+		${tw`w-28 text-white opacity-100 bg-gradient-to-r from-lightBlue to-darkBlue hover:opacity-90  p-1`}
 	}
 	&.greenGradient {
-		${tw`w-36 text-white bg-gradient-to-r from-green-400 to-green-600 hover:from-green-500 hover:to-green-700 p-1`}
+		${tw`w-36 text-white opacity-100 bg-gradient-to-r from-lightGreen to-darkGreen hover:opacity-90  p-1`}
 	}
 	&.darkRed {
-		${tw`w-36 text-white bg-gradient-to-r from-red-400 to-red-600 hover:from-red-500 hover:to-red-700 p-1`}
+		${tw`w-36 text-white opacity-100 bg-darkRed hover:opacity-90  p-1`}
 	}
 	&.darkBlue {
-		${tw`w-28 text-white bg-blue-800 hover:bg-blue-600 m-1 py-1 px-2`}
+		${tw`w-28 text-white opacity-100 bg-darkBlue hover:opacity-90 m-1 py-1 px-2`}
 	}
 	&.disabled {
 		cursor: not-allowed;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,5 +1,3 @@
-const colors = require("tailwindcss/colors");
-
 module.exports = {
 	purge: ["./src/**/*.{js,jsx,ts,tsx}", "./public/index.html"],
 	darkMode: false, // or 'media' or 'class'
@@ -10,15 +8,27 @@ module.exports = {
 		boxShadow: {
 			"button-shadow": "0px 2px 4px #00000029",
 		},
+
 		extend: {
 			colors: {
-				rose: colors.rose,
-				fuchsia: colors.fuchsia,
-				indigo: colors.indigo,
-				teal: colors.teal,
-				lime: colors.lime,
-				orange: colors.orange,
-				sky: colors.sky,
+				white: "#FFFFFF",
+				black: "#000000",
+				mainColor: "#FFA500	",
+				redColor: "#E12D2D",
+				lightBlue: "#46C1F7",
+				darkBlue: "#0073E6",
+				frenchBlue: "#0077B3",
+				lightOrange: "#F76546",
+				darkOrange: "#E62900",
+				lightGreen: "#6DD364",
+				darkGreen: "#249A36",
+				darkRed: "#823434",
+				grey: "#707070",
+				lightGrey: "#999999",
+				lightGray: "#B0B0B0",
+				strongBlue: "#006BB9",
+				extraLightGrey: "D8D8D8",
+				extraDarkBlue: "#074C84",
 			},
 		},
 	},


### PR DESCRIPTION
Added project colors to frontend/tailwind.config for usage throughout the entire app. 

Colors can be added in frontend/tailwind.config.js file 
![project-colors](https://user-images.githubusercontent.com/66978893/133578881-ef4c869d-cdc6-4324-a0fe-a474ea9bcc4c.PNG)
They can then be used as another tailwind class anywhere
![colors-usage](https://user-images.githubusercontent.com/66978893/133578896-9673ab4d-082d-494d-819f-6589d2db74e1.PNG)
