### PR TITLE
add developer role and jsonb field

### DIFF
--- a/backend/prisma/migrations/20220404072037_new_field_user_role_developer/migration.sql
+++ b/backend/prisma/migrations/20220404072037_new_field_user_role_developer/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "user_role" ADD COLUMN     "developer" BOOLEAN NOT NULL DEFAULT false;

--- a/backend/prisma/migrations/20220405103316_new_user_field_developer_data/migration.sql
+++ b/backend/prisma/migrations/20220405103316_new_user_field_developer_data/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "user" ADD COLUMN     "developer_data" JSONB;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -41,26 +41,11 @@ model user {
   user_role        user_role          @relation(fields: [user_role_id], references: [id])
   user_role_id     Int
   acces_log        acces_log[]
-  recover_password recover_password[]
+  recover_password recover_password_log[]
   media            media[]
   ads              ads[]
   developer_data   Json? //Added developer data (not a jsonb?)
 }
-
-// model developer_data {
-//   id          Int      @id @default(autoincrement())
-//   user        user     @relation(fields: [user_id], references: [id])
-//   user_id     Int      @unique
-//   github      String?
-//   linkedin    String?
-//   website     String?
-//   tags        String[]
-//   description String
-//   media_id    media    @relation(fields: [mediaId], references: [id]) //¿cómo relacionar con tabla "media"?
-//   version     Int //como aumenta?
-//   layout_type String //?
-//   mediaId     Int
-// }
 
 model acces_log {
   id      Int      @id @default(autoincrement())

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -12,6 +12,7 @@ model user_role {
   id         Int     @id @default(autoincrement())
   name       String
   admin      Boolean @default(false)
+  developer  Boolean @default(false) //Developer role added
   manager    Boolean @default(false)
   registered Boolean @default(false)
   user       user[]
@@ -43,7 +44,24 @@ model user {
   recover_password recover_password[]
   media            media[]
   ads              ads[]
+  developer_data   Json? //Added developer data (not a jsonb?)
+
 }
+
+// model developer_data {
+//   id          Int      @id @default(autoincrement())
+//   user        user     @relation(fields: [user_id], references: [id])
+//   user_id     Int      @unique
+//   github      String?
+//   linkedin    String?
+//   website     String?
+//   tags        String[]
+//   description String
+//   media_id    media    @relation(fields: [mediaId], references: [id]) //¿cómo relacionar con tabla "media"?
+//   version     Int //como aumenta?
+//   layout_type String //?
+//   mediaId     Int
+// }
 
 model acces_log {
   id      Int      @id @default(autoincrement())
@@ -125,8 +143,8 @@ model ad_type {
 }
 
 model ads {
-  id            Int     @id @default(autoincrement())
-  user          user    @relation(fields: [user_id], references: [id])
+  id            Int      @id @default(autoincrement())
+  user          user     @relation(fields: [user_id], references: [id])
   user_id       Int
   title         String
   description   String
@@ -138,10 +156,10 @@ model ads {
   map_lat       Decimal
   map_lon       Decimal
   ad_type_id    Int
-  ad_type       ad_type @relation(fields: [ad_type_id], references: [id])
-  publish       Boolean   @default(true)
-  createdAt     DateTime  @default(now())
-  updateAt      DateTime  @updateAt
+  ad_type       ad_type  @relation(fields: [ad_type_id], references: [id])
+  publish       Boolean  @default(true)
+  createdAt     DateTime @default(now())
+  updateAt      DateTime @updatedAt
 }
 
 model level {
@@ -155,13 +173,13 @@ model level {
 }
 
 model level_type {
-  id                Int     @id @default(autoincrement())
-  name              String
-  country           Int // País
-  state             Int // Autonomía
-  city              Int // Provincia
-  town              Int // Ciudad-Población
-  district          Int // Distrito
-  neighborhood      Int // Barrio
-  level             level[]
+  id           Int     @id @default(autoincrement())
+  name         String
+  country      Int // País
+  state        Int // Autonomía
+  city         Int // Provincia
+  town         Int // Ciudad-Población
+  district     Int // Distrito
+  neighborhood Int // Barrio
+  level        level[]
 }

--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -28,6 +28,10 @@ const user_roles = [
 		name: "Registered",
 		registered: true,
 	},
+	{
+		name: "Developer",
+		developer: true
+	}
 ];
 
 const user_status = [
@@ -95,6 +99,24 @@ const users = [
 		password: "test5",
 
 	},
+	{
+		name: "testDeveloper",
+		lastnames: "test test",
+		email: "testdev@test.test",
+		user_status_id: 1,
+		user_role_id: 4,
+		password: "testdev",
+		developer_data: {
+			github: "https://test.github.io",
+			linkedin: "linkedin.com/in/test",
+			website: "www.test.com",
+			tags: ["test","test"],
+			description: "test test test",
+			media_id: "", //?
+			version: 1,
+			layout_type: "" //?
+		}
+	}
 ];
 
 const medias = [


### PR DESCRIPTION
In schema.prisma:
- Added developer field in user_role schema. 
- Added developer data (a jsonb field) in user schema.

In seed.js:
- Added dummy data in user_roles and in users.

Also the corresponding migrations have been added.
Doubts: media_id field, version field and layout_type fields.
To do: delete commented developer_data schema, in schema.prisma.

